### PR TITLE
Modify bounding box of 21 targets with poor quality metrics to improve

### DIFF
--- a/dockstring/resources/targets/ADAM17_conf.txt
+++ b/dockstring/resources/targets/ADAM17_conf.txt
@@ -2,6 +2,6 @@ center_x = 44.294
 center_y = 28.123
 center_z = 2.617
 
-size_x = 14.947
-size_y = 14.733
-size_z = 11.222
+size_x = 24.947
+size_y = 24.733
+size_z = 21.222

--- a/dockstring/resources/targets/ADRB2_conf.txt
+++ b/dockstring/resources/targets/ADRB2_conf.txt
@@ -2,6 +2,6 @@ center_x = 2.145
 center_y = 4.681
 center_z = 51.903
 
-size_x = 11.769
-size_y = 15.393
-size_z = 13.645
+size_x = 21.769
+size_y = 25.393
+size_z = 23.645

--- a/dockstring/resources/targets/AKT1_conf.txt
+++ b/dockstring/resources/targets/AKT1_conf.txt
@@ -2,6 +2,6 @@ center_x = 5.507
 center_y = 3.383
 center_z = 18.721
 
-size_x = 12.969
-size_y = 11.698
-size_z = 11.866
+size_x = 22.969
+size_y = 21.698
+size_z = 21.866

--- a/dockstring/resources/targets/AR_conf.txt
+++ b/dockstring/resources/targets/AR_conf.txt
@@ -2,6 +2,6 @@ center_x = 27.060
 center_y = 2.355
 center_z = 4.947
 
-size_x = 12.942
-size_y = 15.204
-size_z = 10.000
+size_x = 22.942
+size_y = 25.204
+size_z = 20.000

--- a/dockstring/resources/targets/CA2_conf.txt
+++ b/dockstring/resources/targets/CA2_conf.txt
@@ -2,6 +2,6 @@ center_x = -5.846
 center_y = 1.074
 center_z = 16.803
 
-size_x = 10.000
-size_y = 10.000
-size_z = 10.000
+size_x = 20.000
+size_y = 20.000
+size_z = 20.000

--- a/dockstring/resources/targets/CDK2_conf.txt
+++ b/dockstring/resources/targets/CDK2_conf.txt
@@ -2,6 +2,6 @@ center_x = 1.633
 center_y = 26.264
 center_z = 9.276
 
-size_x = 15.965
-size_y = 20.729
-size_z = 13.424
+size_x = 25.965
+size_y = 30.729
+size_z = 23.424

--- a/dockstring/resources/targets/CYP2C9_conf.txt
+++ b/dockstring/resources/targets/CYP2C9_conf.txt
@@ -2,6 +2,6 @@ center_x = 7.952
 center_y = 32.818
 center_z = -1.085
 
-size_x = 12.834
-size_y = 14.845
-size_z = 10.425
+size_x = 22.834
+size_y = 24.845
+size_z = 20.425

--- a/dockstring/resources/targets/DRD3_conf.txt
+++ b/dockstring/resources/targets/DRD3_conf.txt
@@ -2,6 +2,6 @@ center_x = 8.970
 center_y = 21.132
 center_z = 24.193
 
-size_x = 12.812
-size_y = 17.187
-size_z = 12.540
+size_x = 22.812
+size_y = 27.187
+size_z = 22.540

--- a/dockstring/resources/targets/FGFR1_conf.txt
+++ b/dockstring/resources/targets/FGFR1_conf.txt
@@ -2,6 +2,6 @@ center_x = 6.174
 center_y = 3.432
 center_z = 18.060
 
-size_x = 10.779
-size_y = 10.000
-size_z = 16.630
+size_x = 20.779
+size_y = 20.000
+size_z = 26.630

--- a/dockstring/resources/targets/GBA_conf.txt
+++ b/dockstring/resources/targets/GBA_conf.txt
@@ -2,6 +2,6 @@ center_x = 36.269
 center_y = 31.750
 center_z = 0.529
 
-size_x = 12.399
-size_y = 11.177
-size_z = 11.729
+size_x = 22.399
+size_y = 21.177
+size_z = 21.729

--- a/dockstring/resources/targets/HSP90AA1_conf.txt
+++ b/dockstring/resources/targets/HSP90AA1_conf.txt
@@ -2,6 +2,6 @@ center_x = 2.681
 center_y = 12.958
 center_z = 25.366
 
-size_x = 16.116
-size_y = 12.633
-size_z = 11.308
+size_x = 26.116
+size_y = 22.633
+size_z = 21.308

--- a/dockstring/resources/targets/KDR_conf.txt
+++ b/dockstring/resources/targets/KDR_conf.txt
@@ -2,6 +2,6 @@ center_x = 37.081
 center_y = 36.130
 center_z = 11.946
 
-size_x = 12.280
-size_y = 23.706
-size_z = 11.646
+size_x = 22.280
+size_y = 33.706
+size_z = 21.646

--- a/dockstring/resources/targets/KIT_conf.txt
+++ b/dockstring/resources/targets/KIT_conf.txt
@@ -2,6 +2,6 @@ center_x = 34.300
 center_y = -3.274
 center_z = -27.964
 
-size_x = 13.849
-size_y = 17.015
-size_z = 10.000
+size_x = 23.849
+size_y = 27.015
+size_z = 20.000

--- a/dockstring/resources/targets/MAPK1_conf.txt
+++ b/dockstring/resources/targets/MAPK1_conf.txt
@@ -2,6 +2,6 @@ center_x = -13.754
 center_y = 14.001
 center_z = 41.802
 
-size_x = 15.141
-size_y = 12.601
-size_z = 11.602
+size_x = 25.141
+size_y = 22.601
+size_z = 21.602

--- a/dockstring/resources/targets/NOS1_conf.txt
+++ b/dockstring/resources/targets/NOS1_conf.txt
@@ -2,6 +2,6 @@ center_x = 1.235
 center_y = 0.125
 center_z = 59.832
 
-size_x = 13.268
-size_y = 11.266
-size_z = 12.304
+size_x = 23.267
+size_y = 21.266
+size_z = 22.304

--- a/dockstring/resources/targets/PARP1_conf.txt
+++ b/dockstring/resources/targets/PARP1_conf.txt
@@ -2,6 +2,6 @@ center_x = 26.835
 center_y = 11.332
 center_z = 27.744
 
-size_x = 14.495
-size_y = 14.441
-size_z = 16.006
+size_x = 24.495
+size_y = 24.441
+size_z = 26.006

--- a/dockstring/resources/targets/PGR_conf.txt
+++ b/dockstring/resources/targets/PGR_conf.txt
@@ -2,6 +2,6 @@ center_x = -2.532
 center_y = -8.387
 center_z = 25.099
 
-size_x = 11.472
-size_y = 13.360
-size_z = 17.073
+size_x = 21.472
+size_y = 23.360
+size_z = 27.073

--- a/dockstring/resources/targets/PTGS2_conf.txt
+++ b/dockstring/resources/targets/PTGS2_conf.txt
@@ -2,6 +2,6 @@ center_x = 30.101
 center_y = -23.094
 center_z = -15.400
 
-size_x = 16.430
-size_y = 11.531
-size_z = 14.619
+size_x = 26.430
+size_y = 21.531
+size_z = 24.619

--- a/dockstring/resources/targets/PTPN1_conf.txt
+++ b/dockstring/resources/targets/PTPN1_conf.txt
@@ -2,6 +2,6 @@ center_x = 46.162
 center_y = 13.754
 center_z = 3.076
 
-size_x = 10.000
-size_y = 12.764
-size_z = 10.340
+size_x = 20.000
+size_y = 22.764
+size_z = 20.340

--- a/dockstring/resources/targets/SRC_conf.txt
+++ b/dockstring/resources/targets/SRC_conf.txt
@@ -2,6 +2,6 @@ center_x = 1.792
 center_y = 5.091
 center_z = 6.855
 
-size_x = 20.026
-size_y = 19.405
-size_z = 11.659
+size_x = 30.026
+size_y = 29.405
+size_z = 21.659

--- a/dockstring/resources/targets/THRB_conf.txt
+++ b/dockstring/resources/targets/THRB_conf.txt
@@ -2,6 +2,6 @@ center_x = 13.230
 center_y = 23.118
 center_z = 46.569
 
-size_x = 14.438
-size_y = 14.242
-size_z = 16.947
+size_x = 24.438
+size_y = 24.242
+size_z = 26.947


### PR DESCRIPTION
quality metrics

Targets for which the box size is increased and the center is changed:
- CA2
- FGFR1
- PGR
- CDK2
- SRC

Targets for which the box size is increased and the center is kept:
- AKT1
- ADAM17
- ADRB2
- AR
- CYP2C9
- GBA
- HSP90AA1
- KIT
- MAPK1
- NOS1
- PARP1
- PTPN1
- PTGS2
- DRD3
- THRB
- KDR