### PR TITLE
Add openbabel version checking command to target.dock

### DIFF
--- a/dockstring/dockstring.py
+++ b/dockstring/dockstring.py
@@ -12,7 +12,7 @@ from .utils import (DockingError, smiles_to_mol, embed_mol, refine_mol_with_ff, 
                     parse_scores_from_output, parse_search_box_conf, PathType, get_targets_dir, get_vina_path,
                     get_resources_dir, check_mol, canonicalize_smiles, verify_docked_ligand, check_vina_output,
                     assign_stereochemistry, assign_bond_orders, sanitize_mol, protonate_mol, write_mol_to_mol_file,
-                    convert_mol_file_to_pdbqt, check_charges)
+                    convert_mol_file_to_pdbqt, check_charges, check_obabel_install)
 
 
 def load_target(name: str, *args, **kwargs):
@@ -127,6 +127,9 @@ class Target:
             mol = sanitize_mol(mol, verbose=verbose)
             check_mol(mol)
             check_charges(mol)
+
+            # Check that the right openbabel version is available
+            check_obabel_install()
 
             # Protonate ligand
             protonated_mol = protonate_mol(mol)

--- a/dockstring/utils.py
+++ b/dockstring/utils.py
@@ -172,6 +172,18 @@ def refine_mol_with_ff(mol, max_iters=1000) -> Chem.Mol:
     return opt_mol
 
 
+def check_obabel_install():
+    """ Check that openbabel is installed correctly / is the correct version """
+    cmd_args = ["obabel", "-V"]
+    cmd_return = subprocess.run(cmd_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    stdout = cmd_return.stdout.decode('utf-8').strip()
+    obabel_version_match = stdout == "Open Babel 3.1.0 -- Oct 12 2020 -- 14:17:21"
+    if cmd_return.returncode != 0:
+        raise DockingError(f"The test command `{' '.join(cmd_args)}` failed!")
+    elif not obabel_version_match:
+        raise DockingError("The obabel test command succeeded but the version doesn't seem to match.")
+
+
 def convert_pdbqt_to_pdb(pdbqt_file: PathType, pdb_file: PathType, disable_bonding=False, verbose=False) -> None:
     # yapf: disable
     cmd_args = [


### PR DESCRIPTION
I just accidentally tried docking in a conda env without open babel and the error I got was that "protonation failed". While this is technically true because protonation requires openbabel, I think it would be better to output a more specific error message if openbabel is not installed.

My solution: when calling `target.dock`, call `obabel -V` and check that this command succeeds and that the version is right. This seems like a simple solution, although currently the openbabel version is hardcoded which isn't ideal. Thoughts @gncs  @mgarort ?