### PR TITLE
Modify dockstring to not use default logger.

### DIFF
--- a/dockstring/utils.py
+++ b/dockstring/utils.py
@@ -18,7 +18,7 @@ PathType = Union[str, os.PathLike]
 
 
 def setup_logger(level: Union[int, str] = logging.INFO, path: Optional[str] = None):
-    logger = logging.getLogger()
+    logger = logging.getLogger("dockstring")
     logger.setLevel(level)
 
     formatter = logging.Formatter('%(asctime)s.%(msecs)03d %(levelname)s: %(message)s', datefmt='%Y-%m-%d %H:%M:%S')


### PR DESCRIPTION
When dockstring is being used with another program, modifying
the default logger might interfere with other loggers.
Therefore I think it should use its own logger.