### PR TITLE
Removes a dependency to `pkg-resources` in utils

### DIFF
--- a/dockstring/utils.py
+++ b/dockstring/utils.py
@@ -9,7 +9,6 @@ import warnings
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 
-import pkg_resources  # type: ignore  # no type hints for this package
 from rdkit import rdBase
 from rdkit.Chem import AllChem as Chem
 from rdkit.Chem.Descriptors import NumRadicalElectrons
@@ -87,7 +86,7 @@ def get_vina_filename() -> str:
 
 def get_resources_dir() -> Path:
     """Directory of resources (including targets and binaries)."""
-    path = Path(pkg_resources.resource_filename(__package__, 'resources'))
+    path = Path(__file__).parent.resolve() / "resources"
     if not path.is_dir():
         raise DockstringError("'resources' directory not found")
     return path


### PR DESCRIPTION
Hi dockstring developers,

I'm currently running into some issues in another project that depends on `dockstring` because of the `pkg-resources` dependency.

I'm using the following `conda` environment:

```yaml
name: poli__dockstring
channels:
  - conda-forge
  - defaults
dependencies:
  - python=3.9
  - openbabel
  - pip
  - pip:
    - "git+https://github.com/MachineLearningLifeScience/poli.git@dev"
    - rdkit
    - selfies
    - dockstring
```

And my GitHub action runs into the following issue:

```
E           Traceback (most recent call last):
E             File "/home/runner/work/poli/poli/.tox/poli-dockstring-py39/lib/python3.9/site-packages/poli/objective_repository/dockstring/isolated_function.py", line 4, in <module>
E               from dockstring import load_target
E             File "/usr/share/miniconda/envs/poli__dockstring/lib/python3.9/site-packages/dockstring/__init__.py", line 17, in <module>
E               from .target import list_all_target_names, load_target
E             File "/usr/share/miniconda/envs/poli__dockstring/lib/python3.9/site-packages/dockstring/target.py", line 14, in <module>
E               from .utils import (
E             File "/usr/share/miniconda/envs/poli__dockstring/lib/python3.9/site-packages/dockstring/utils.py", line 12, in <module>
E               import pkg_resources  # type: ignore  # no type hints for this package
E           ModuleNotFoundError: No module named 'pkg_resources'
```

I'm not exactly sure when `pkg-resources` was deprecated, [but it has been marked for deprecation a long while ago (in favor of `importlib`)](https://setuptools.pypa.io/en/latest/pkg_resources.html). I've tried adding it to my dependencies, but `pip` can't find it.

The only place where `pkg-resources` is used in the codebase is in the `utils.py`, where it's used to determine the path of the `resources` folder.

In this PR I remove that dependency, and change the relative path using `Path(__file__).parent.resolve() / "resources"`. I'm not exactly sure it'll work on CI yet, because I don't know if the `resources` folder is carried with the `pip` installation. 

I'm happy to change it for the recommended `importlib` alternative.